### PR TITLE
Fix final table generation after skipping all offers

### DIFF
--- a/main.py
+++ b/main.py
@@ -985,7 +985,14 @@ def on_skip_offer(call: types.CallbackQuery):
     else:
         # якщо оферів більше немає — генеруємо фінальний файл
         try:
-            send_final_table(call.message, state)
+            final_df = build_final_output(state)
+            if final_df.empty:
+                bot.send_message(
+                    chat_id,
+                    "ℹ️ Після пропуску всіх оферів не залишилось даних для експорту.",
+                )
+            else:
+                send_final_table(call.message, final_df)
         except Exception as e:
             bot.send_message(chat_id, f"⚠️ Помилка під час формування файлу: <code>{e}</code>")
 


### PR DESCRIPTION
## Summary
- build the final DataFrame before exporting when all offers are skipped
- prevent export when no rows remain and inform the user instead

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64c2f5e24832387860a028c244fa8