### PR TITLE
Add red-cap phase to max yellow allocation

### DIFF
--- a/main.py
+++ b/main.py
@@ -759,7 +759,9 @@ def compute_allocation_max_yellow(df: pd.DataFrame) -> Tuple[pd.DataFrame, float
       - кожен рядок має цільовий spend у колонці "Total+%" (верхня межа);
       - доступний глобальний бюджет = вся поточна сума в колонці "Total spend";
       - розподіл іде за зростанням Target: спершу переводимо green у yellow,
-        потім (якщо лишилися кошти) насичуємо жовті в межах CPA < target×YELLOW_MULT і нижче межі target×RED_MULT.
+        потім (якщо лишилися кошти) насичуємо жовті в межах CPA < target×YELLOW_MULT
+        та нижче межі target×RED_MULT, а за наявності залишку доводимо рядки до
+        червоного порогу (red_ceiling).
     Повертає оновлену таблицю, фактично розподілений бюджет та фінальні значення spend по рядках.
     """
 
@@ -784,6 +786,7 @@ def compute_allocation_max_yellow(df: pd.DataFrame) -> Tuple[pd.DataFrame, float
     available_budget = float(F.sum())
 
     order = T.sort_values(ascending=True).index.tolist()
+    order_by_total_spend = F.sort_values(ascending=True).index.tolist()
     alloc = pd.Series(0.0, index=dfw.index, dtype=float)
     rem = available_budget
 
@@ -844,6 +847,28 @@ def compute_allocation_max_yellow(df: pd.DataFrame) -> Tuple[pd.DataFrame, float
             if head <= 1e-9:
                 continue
             give = min(rem, head, allowance_left)
+            if give <= 1e-9:
+                continue
+            alloc.at[idx] += give
+            rem -= give
+
+    # Крок 3: доводимо до червоного стелі, якщо бюджет ще лишився
+    if rem > 1e-9:
+        red_caps = thresholds["red_ceiling"].fillna(0.0)
+        for idx in order_by_total_spend:
+            if rem <= 1e-9:
+                break
+            if float(E.at[idx]) <= 0:
+                continue
+            allowance_left = float(row_allowance.at[idx] - alloc.at[idx])
+            if allowance_left <= 1e-9:
+                continue
+            cap = min(float(red_caps.at[idx]), float(row_allowance.at[idx]))
+            current = float(alloc.at[idx])
+            need = cap - current
+            if need <= 1e-9:
+                continue
+            give = min(rem, need, allowance_left)
             if give <= 1e-9:
                 continue
             alloc.at[idx] += give
@@ -1188,7 +1213,7 @@ def on_document(message: types.Message):
                 )
 
                 summary = (
-                    "Режим: максимум жовтих (Total+% цілі).\n"
+                    "Режим: максимум жовтих (Total+% цілі) з доведенням до red-ceiling.\n"
                     f"Початковий бюджет (сума Total spend): {starting_budget:.2f}; розподілено: {used_budget:.2f}; невикористано: {unused_budget:.2f}\n"
                     f"Жовтих після розподілу: {yellow_after}/{total_posE} (зел.→жовт.: {green_to_yellow})"
                 )

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -1,0 +1,53 @@
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Ensure the bot token is present before importing the bot module
+os.environ.setdefault("BOT_TOKEN", "0:TEST")
+
+from main import (  # noqa: E402
+    _build_threshold_table,
+    _extract_targets,
+    compute_allocation_max_yellow,
+)
+
+
+def test_allocation_continues_to_red_cap_when_budget_remains():
+    df = pd.DataFrame(
+        {
+            "FTD qty": [10, 12],
+            "Total spend": [200.0, 200.0],
+            "Total Dep Amount": [150.0, 180.0],
+            "Total+%": [500.0, 500.0],
+            "CPA Target": [8.0, 8.0],
+        },
+        index=["row_a", "row_b"],
+    )
+
+    result_df, used_budget, alloc_vec = compute_allocation_max_yellow(df)
+    assert not result_df.empty
+
+    E = pd.to_numeric(df.get("FTD qty"), errors="coerce").fillna(0.0)
+    K = pd.to_numeric(df.get("Total Dep Amount"), errors="coerce").fillna(0.0)
+    targets, target_ints = _extract_targets(df)
+    thresholds = _build_threshold_table(E, K, targets, target_ints)
+
+    red_caps = thresholds["red_ceiling"].astype(float)
+    yellow_caps = thresholds["yellow_soft_ceiling"].astype(float)
+
+    # Переконуємося, що після доведення до жовтого ще є запас бюджету
+    assert float(df["Total spend"].sum()) > float(yellow_caps.sum()) + 1e-6
+
+    # Алгоритм повинен довести рядки до red_ceiling, коли бюджет усе ще доступний
+    np.testing.assert_allclose(alloc_vec.to_numpy(dtype=float), red_caps.to_numpy(dtype=float))
+    assert used_budget == pytest.approx(float(red_caps.sum()))
+    assert used_budget > float(yellow_caps.sum())


### PR DESCRIPTION
## Summary
- extend the max-yellow allocator with a final pass that spends remaining budget up to each row's red ceiling
- update the mode summary to reference the red-cap step so users know the extra budget usage
- add a pytest verifying that surplus budget drives allocations to the red ceiling instead of stopping at yellow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d66b9398788323beb2683f736a3087