### PR TITLE
Fix max-yellow status calculation with row-specific CPA targets

### DIFF
--- a/main.py
+++ b/main.py
@@ -1301,9 +1301,16 @@ def on_document(message: types.Message):
                 K = pd.to_numeric(df_norm.get("Total Dep Amount", 0.0), errors="coerce").fillna(0.0)
                 F_before = total_spend
                 F_after = pd.to_numeric(alloc_vec, errors="coerce").reindex(df_norm.index).fillna(0.0)
+                targets, _ = _extract_targets(df_norm)
 
-                before_status = [_classify_status(float(E[i]), float(F_before[i]), float(K[i])) for i in df_norm.index]
-                after_status = [_classify_status(float(E[i]), float(F_after[i]), float(K[i])) for i in df_norm.index]
+                before_status = [
+                    _classify_status(float(E[i]), float(F_before[i]), float(K[i]), float(targets.at[i]))
+                    for i in df_norm.index
+                ]
+                after_status = [
+                    _classify_status(float(E[i]), float(F_after[i]), float(K[i]), float(targets.at[i]))
+                    for i in df_norm.index
+                ]
 
                 total_posE = int((E > 0).sum())
                 yellow_after = sum(1 for s in after_status if s == "Yellow")

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -293,6 +293,35 @@ def test_classify_status_uses_red_cutoff_from_below_and_excel_rule_matches():
     assert any(f"$H2<=$I2*{main_mod.RED_MULT:.1f}" in f for f in red_rule_formulae)
 
 
+def test_allocation_explanation_reflects_custom_targets_in_status_counts():
+    os.environ["BOT_TOKEN"] = "258:CUSTOM"
+    main_mod = importlib.reload(importlib.import_module("main"))
+
+    df = pd.DataFrame(
+        {
+            "Назва Офферу": ["Offer X"],
+            "ГЕО": ["UA"],
+            "FTD qty": [10],
+            "Total spend": [50.0],
+            "Total Dep Amount": [400.0],
+            "Total+%": [120.0],
+            "CPA Target": [5.0],
+        }
+    )
+
+    alloc_vec = pd.Series([65.0], index=df.index, dtype=float)
+
+    explanation = main_mod.build_allocation_explanation(
+        df,
+        alloc_vec,
+        budget=float(df["Total spend"].sum()),
+        alloc_is_delta=False,
+    )
+
+    assert "Жовтих ДО/ПІСЛЯ: 1 → 0" in explanation
+    assert "Yellow → Red" in explanation
+
+
 def test_read_result_allocation_table_handles_formula_total_plus_percent(tmp_path):
     os.environ["BOT_TOKEN"] = "456:FORM"
     main_mod = importlib.reload(importlib.import_module("main"))


### PR DESCRIPTION
## Summary
- ensure the max-yellow allocation summary classifies before/after statuses with the per-row CPA target extracted from the sheet
- add a regression test that verifies build_allocation_explanation reports the red status when a custom CPA target is exceeded

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c385ca108323a3a297dc005174ff