### PR TITLE
Align red ceiling with CPA spend calculation

### DIFF
--- a/main.py
+++ b/main.py
@@ -676,7 +676,7 @@ def _build_threshold_table(E: pd.Series, K: pd.Series, targets: pd.Series, targe
         green_cpa_limit = np.where(e > 0, (tint * e) / 1.3, 0.0)
         deposit_break = np.where((k > 0) & (DEPOSIT_GREEN_MIN > 0), (100.0 * k) / (1.3 * DEPOSIT_GREEN_MIN), 0.0)
         yellow_soft = np.where(e > 0, (t * YELLOW_MULT * e) / 1.3, 0.0)
-        red_limit = np.where(e > 0, (t * RED_MULT * e) / 1.8, 0.0)
+        red_limit = np.where(e > 0, (t * RED_MULT * e) / 1.3, 0.0)
 
     red_ceiling = np.maximum(red_limit - EPS_YEL, 0.0)
     yellow_soft = np.minimum(yellow_soft, red_ceiling)
@@ -1230,7 +1230,7 @@ def write_result_like_excel_with_new_spend(bio: io.BytesIO,
         ws.conditional_formatting.add(data_range, FormulaRule(formula=[yellow_formula], fill=yellow,
                                                               stopIfTrue=True))
         ws.conditional_formatting.add(data_range,
-                                      FormulaRule(formula=[f"AND($E2>0,$H2<$I2*{1.81:.1f})"], fill=red, stopIfTrue=True))
+                                      FormulaRule(formula=[f"AND($E2>0,$H2<=$I2*{1.81:.1f})"], fill=red, stopIfTrue=True))
 
 
 # ===================== BOT HANDLERS =====================
@@ -1887,7 +1887,7 @@ def send_final_table(message: types.Message, df: pd.DataFrame):
         )
         ws.conditional_formatting.add(
             data_range,
-            FormulaRule(formula=[f"AND($E2>0,$H2<$I2*{1.81:.1f})"], fill=red, stopIfTrue=True),
+            FormulaRule(formula=[f"AND($E2>0,$H2<=$I2*{1.81:.1f})"], fill=red, stopIfTrue=True),
         )
 
     bio.seek(0)

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -16,6 +16,8 @@ if str(ROOT) not in sys.path:
 os.environ.setdefault("BOT_TOKEN", "0:TEST")
 
 from main import (  # noqa: E402
+    EPS_YEL,
+    RED_MULT,
     _build_threshold_table,
     _extract_targets,
     compute_allocation_max_yellow,
@@ -44,6 +46,13 @@ def test_allocation_continues_to_red_cap_when_budget_remains():
 
     red_caps = thresholds["red_ceiling"].astype(float)
     yellow_caps = thresholds["yellow_soft_ceiling"].astype(float)
+
+    expected_red_caps = (
+        (targets.to_numpy(dtype=float) * RED_MULT * E.to_numpy(dtype=float)) / 1.3
+    ) - EPS_YEL
+    expected_red_caps = np.maximum(expected_red_caps, 0.0)
+
+    np.testing.assert_allclose(red_caps.to_numpy(dtype=float), expected_red_caps, rtol=1e-6, atol=1e-6)
 
     assert float(df["Total spend"].sum()) > float(yellow_caps.sum()) + 1e-6
 
@@ -301,7 +310,7 @@ def test_allocation_explanation_reflects_custom_targets_in_status_counts():
         {
             "Назва Офферу": ["Offer X"],
             "ГЕО": ["UA"],
-            "FTD qty": [10],
+            "FTD qty": [11],
             "Total spend": [50.0],
             "Total Dep Amount": [400.0],
             "Total+%": [120.0],


### PR DESCRIPTION
## Summary
- update the red ceiling computation to use the same CPA-to-spend factor as _calc_cpa
- keep spreadsheet conditional formatting consistent with the inclusive red threshold
- adjust allocation tests to cover the updated ceiling and refreshed status expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a82d79888323908d33b1450d5232