### PR TITLE
Align status classification with new red band

### DIFF
--- a/main.py
+++ b/main.py
@@ -675,12 +675,15 @@ def _build_threshold_table(E: pd.Series, K: pd.Series, targets: pd.Series, targe
     with np.errstate(divide='ignore', invalid='ignore'):
         green_cpa_limit = np.where(e > 0, (tint * e) / 1.3, 0.0)
         deposit_break = np.where((k > 0) & (DEPOSIT_GREEN_MIN > 0), (100.0 * k) / (1.3 * DEPOSIT_GREEN_MIN), 0.0)
-        yellow_soft = np.where(e > 0, (t * YELLOW_MULT * e) / 1.3, 0.0)
-        red_limit = np.where(e > 0, (t * RED_MULT * e) / 1.3, 0.0)
+        yellow_soft_raw = np.where(e > 0, (t * YELLOW_MULT * e) / 1.3, 0.0)
+        red_limit_raw = np.where(e > 0, (t * RED_MULT * e) / 1.3, 0.0)
 
-    red_ceiling = np.maximum(red_limit - EPS_YEL, 0.0)
-    yellow_soft = np.minimum(yellow_soft, red_ceiling)
+    red_ceiling = np.maximum(red_limit_raw - EPS_YEL, 0.0)
+    red_floor = np.minimum(yellow_soft_raw, red_ceiling)
+    red_floor = np.maximum(red_floor - EPS_YEL, 0.0)
+    yellow_soft = np.minimum(np.maximum(yellow_soft_raw - EPS_YEL, 0.0), red_floor)
     green_ceiling = np.minimum(green_cpa_limit, np.maximum(deposit_break - EPS_YEL, 0.0))
+    green_ceiling = np.minimum(green_ceiling, red_floor)
 
     return pd.DataFrame({
         "target": t,
@@ -688,6 +691,7 @@ def _build_threshold_table(E: pd.Series, K: pd.Series, targets: pd.Series, targe
         "green_cpa_limit": green_cpa_limit,
         "deposit_break": deposit_break,
         "green_ceiling": green_ceiling,
+        "red_floor": red_floor,
         "yellow_soft_ceiling": yellow_soft,
         "red_ceiling": red_ceiling,
     }, index=E.index)
@@ -719,6 +723,10 @@ def _compute_make_yellow_target(e: float, f_cur: float, k: float, thresholds_row
     if yellow_soft > 0:
         candidates = [min(c, yellow_soft) for c in candidates]
 
+    red_floor = float(thresholds_row.get("red_floor", 0.0))
+    if red_floor > 0:
+        candidates = [min(c, red_floor) for c in candidates]
+
     target_value = min(candidates)
     return target_value if target_value > f_cur + EPS else None
 
@@ -732,6 +740,11 @@ def _compute_yellow_limit(e: float, f_cur: float, k: float, thresholds_row: pd.S
         limit = float(thresholds_row.get("yellow_soft_ceiling", 0.0))
     else:
         limit = max(0.0, float(thresholds_row.get("green_cpa_limit", 0.0)) - EPS_YEL)
+
+    red_floor = float(thresholds_row.get("red_floor", 0.0))
+    if red_floor > 0:
+        limit = min(limit, red_floor)
+
     return min(max(limit, 0.0), red_ceiling)
 
 
@@ -743,20 +756,20 @@ def _classify_status(E: float, F: float, K: float, target: Optional[float] = Non
     deposit_pct = _calc_deposit_pct(K, F)
 
     deposit_green_cutoff = DEPOSIT_GREEN_MIN + DEPOSIT_TOL
-    yellow_upper_bound = target_val * YELLOW_MULT
+    red_lower_bound = target_val * YELLOW_MULT
     red_upper_bound = target_val * RED_MULT
 
     if (deposit_pct > deposit_green_cutoff) and (cpa <= target_int + CPA_TOL):
         return "Green"
 
     if deposit_pct > deposit_green_cutoff:
-        if (cpa >= target_int - CPA_TOL) and (cpa < yellow_upper_bound - CPA_TOL):
+        if (cpa >= target_int - CPA_TOL) and (cpa < red_lower_bound - CPA_TOL):
             return "Yellow"
     else:
         if cpa <= target_int - CPA_TOL:
             return "Yellow"
 
-    if cpa > red_upper_bound + CPA_TOL:
+    if (cpa >= red_lower_bound - CPA_TOL) and (cpa <= red_upper_bound + CPA_TOL):
         return "Red"
 
     return "Grey"
@@ -862,7 +875,7 @@ def build_allocation_explanation(df_source: pd.DataFrame,
         f"Розподіл бюджету: {used:.2f} / {total_budget:.2f} використано; залишок {left:.2f}\n"
         f"Жовтих ДО/ПІСЛЯ: {yellow_before} → {yellow_after} (зел.→жовт.: {green_to_yellow})\n"
         f"Правила: green — CPA≤INT(target) і депозит>{DEPOSIT_GREEN_MIN:.0f}%, yellow — або депозит>{DEPOSIT_GREEN_MIN:.0f}% із CPA в діапазоні [INT(target); target×{YELLOW_MULT:.2f}),"
-        f" або депозит≤{DEPOSIT_GREEN_MIN:.0f}% із CPA<INT(target); red — CPA>target×{RED_MULT:.1f}."
+        f" або депозит≤{DEPOSIT_GREEN_MIN:.0f}% із CPA<INT(target); red — CPA в межах [target×{YELLOW_MULT:.2f}; target×{RED_MULT:.1f}]."
     )
 
     header = html.escape(header)
@@ -881,9 +894,9 @@ def compute_allocation_max_yellow(df: pd.DataFrame) -> Tuple[pd.DataFrame, float
       - доступний глобальний бюджет = вся поточна сума в колонці "Total spend";
       - розподіл іде за зростанням Target: спершу переводимо green у yellow,
         потім (якщо лишилися кошти) насичуємо жовті в межах CPA < target×YELLOW_MULT
-        та не перетинаючи межу target×RED_MULT, а за наявності залишку доводимо
-        рядки до червоного порогу (red_ceiling), де перевищення target×RED_MULT
-        стає червоною зоною.
+        та не виходячи за межі [target×YELLOW_MULT; target×RED_MULT], а за наявності
+        залишку доводимо рядки до червоного порогу (red_ceiling), де CPA в діапазоні
+        [target×YELLOW_MULT; target×RED_MULT] відповідає червоній зоні.
     Повертає оновлену таблицю, фактично розподілений бюджет та фінальні значення spend по рядках.
     """
 
@@ -1017,7 +1030,7 @@ def compute_optimal_allocation(df: pd.DataFrame, budget: float) -> Tuple[pd.Data
     """
     Алгоритм нового розподілу:
       A) Мінімально переводимо GREEN → YELLOW (рухаємо CPA до INT(target) або депозит до 39%, не перетинаючи червону межу).
-      B) Якщо залишився бюджет — насичуємо жовті, але тримаємося в межах CPA < target×YELLOW_MULT та не перетинаємо червону межу target×RED_MULT (перевищення → Red).
+      B) Якщо залишився бюджет — насичуємо жовті, але тримаємося в межах CPA < target×YELLOW_MULT та не заходимо у червону зону [target×YELLOW_MULT; target×RED_MULT] (ця зона → Red).
 
     Позначення:
       E = FTD qty,
@@ -1117,7 +1130,7 @@ def compute_optimal_allocation(df: pd.DataFrame, budget: float) -> Tuple[pd.Data
         f"Бюджет: {budget:.2f}\n"
         f"Жовтих після розподілу: {kept_yellow}/{total_posE}\n"
         f"Правила: green — CPA≤INT(target) і депозит>{DEPOSIT_GREEN_MIN:.0f}%, yellow — тримаємо CPA нижче target×{YELLOW_MULT:.2f} "
-        f"(або депозит≤{DEPOSIT_GREEN_MIN:.0f}% із CPA<INT(target)), red — CPA>target×{RED_MULT:.1f}."
+        f"(або депозит≤{DEPOSIT_GREEN_MIN:.0f}% із CPA<INT(target)), red — CPA в межах [target×{YELLOW_MULT:.2f}; target×{RED_MULT:.1f}]."
     )
     return dfw, summary, alloc
 
@@ -1233,7 +1246,9 @@ def write_result_like_excel_with_new_spend(bio: io.BytesIO,
         ws.conditional_formatting.add(
             data_range,
             FormulaRule(
-                formula=[f"AND($E2>0,$H2>$I2*{RED_MULT:.2f})"],
+                formula=[
+                    f"AND($E2>0,$H2>=$I2*{YELLOW_MULT:.2f},$H2<=$I2*{RED_MULT:.2f})"
+                ],
                 fill=red,
                 stopIfTrue=True,
             ),
@@ -1895,7 +1910,9 @@ def send_final_table(message: types.Message, df: pd.DataFrame):
         ws.conditional_formatting.add(
             data_range,
             FormulaRule(
-                formula=[f"AND($E2>0,$H2>$I2*{RED_MULT:.2f})"],
+                formula=[
+                    f"AND($E2>0,$H2>=$I2*{YELLOW_MULT:.2f},$H2<=$I2*{RED_MULT:.2f})"
+                ],
                 fill=red,
                 stopIfTrue=True,
             ),

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -232,39 +232,56 @@ def test_classify_status_marks_red_only_above_cutoff_and_excel_rule_matches():
     target = 8.0
     red_cutoff = target * main_mod.RED_MULT
 
-    cpa_below = red_cutoff - 0.1
-    f_below = (cpa_below * e) / 1.3
-    deposit_below = 1.3 * f_below * 0.5
-    assert main_mod._classify_status(e, f_below, deposit_below, target) == "Grey"
+    cpa_yellow_edge = target * main_mod.YELLOW_MULT - 0.05
+    f_yellow_edge = (cpa_yellow_edge * e) / 1.3
+    deposit_yellow_edge = 1.3 * f_yellow_edge * 0.5
+    assert main_mod._classify_status(e, f_yellow_edge, deposit_yellow_edge, target) == "Yellow"
+
+    cpa_lower = target * main_mod.YELLOW_MULT
+    f_lower = (cpa_lower * e) / 1.3
+    deposit_lower = 1.3 * f_lower * 0.5
+    status_lower = main_mod._classify_status(e, f_lower, deposit_lower, target)
+    assert status_lower == "Red"
+
+    cpa_mid = target * (main_mod.YELLOW_MULT + main_mod.RED_MULT) / 2
+    f_mid = (cpa_mid * e) / 1.3
+    deposit_mid = 1.3 * f_mid * 0.5
+    status_mid = main_mod._classify_status(e, f_mid, deposit_mid, target)
+    assert status_mid == "Red"
 
     cpa_equal = red_cutoff
     f_equal = (cpa_equal * e) / 1.3
     deposit_equal = 1.3 * f_equal * 0.5
     status_equal = main_mod._classify_status(e, f_equal, deposit_equal, target)
-    assert status_equal == "Grey"
+    assert status_equal == "Red"
 
-    cpa_above = red_cutoff + 0.1
-    f_above = (cpa_above * e) / 1.3
-    deposit_above = 1.3 * f_above * 0.5
-    status_above = main_mod._classify_status(e, f_above, deposit_above, target)
-    assert status_above == "Red"
+    cpa_far = red_cutoff + 1.0
+    f_far = (cpa_far * e) / 1.3
+    deposit_far = 1.3 * f_far * 0.5
+    assert main_mod._classify_status(e, f_far, deposit_far, target) == "Grey"
 
     df = pd.DataFrame(
         {
-            "Subid": ["s_below", "s_equal", "s_above"],
-            "Offer ID": ["o1", "o2", "o3"],
-            "Назва Офферу": ["Offer", "Offer", "Offer"],
-            "ГЕО": ["G1", "G2", "G3"],
-            "FTD qty": [e, e, e],
-            "Total spend": [0.0, 0.0, 0.0],
-            "Total Dep Amount": [deposit_below, deposit_equal, deposit_above],
-            "CPA Target": [target, target, target],
+            "Subid": ["s_yellow", "s_lower", "s_mid", "s_upper", "s_far"],
+            "Offer ID": ["o1", "o2", "o3", "o4", "o5"],
+            "Назва Офферу": ["Offer", "Offer", "Offer", "Offer", "Offer"],
+            "ГЕО": ["G1", "G2", "G3", "G4", "G5"],
+            "FTD qty": [e, e, e, e, e],
+            "Total spend": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "Total Dep Amount": [
+                deposit_yellow_edge,
+                deposit_lower,
+                deposit_mid,
+                deposit_equal,
+                deposit_far,
+            ],
+            "CPA Target": [target, target, target, target, target],
         },
-        index=["s_below", "s_equal", "s_above"],
+        index=["s_yellow", "s_lower", "s_mid", "s_upper", "s_far"],
     )
 
     bio = io.BytesIO()
-    new_spend = pd.Series([f_below, f_equal, f_above], index=df.index)
+    new_spend = pd.Series([f_yellow_edge, f_lower, f_mid, f_equal, f_far], index=df.index)
     main_mod.write_result_like_excel_with_new_spend(
         bio,
         df,
@@ -275,17 +292,23 @@ def test_classify_status_marks_red_only_above_cutoff_and_excel_rule_matches():
     wb = load_workbook(bio)
     ws = wb["Result"]
 
-    eq_row_excel = df.index.get_loc("s_equal") + 2
-    e_cell = ws[f"E{eq_row_excel}"]
-    f_cell = ws[f"F{eq_row_excel}"]
-    i_cell = ws[f"I{eq_row_excel}"]
+    upper_row_excel = df.index.get_loc("s_upper") + 2
+    lower_row_excel = df.index.get_loc("s_lower") + 2
+
+    e_cell = ws[f"E{upper_row_excel}"]
+    f_cell = ws[f"F{upper_row_excel}"]
+    i_cell = ws[f"I{upper_row_excel}"]
 
     assert e_cell.value == pytest.approx(e)
     assert f_cell.value == pytest.approx(f_equal, rel=0, abs=1e-6)
 
     computed_cpa = 1.3 * f_cell.value / e_cell.value
     assert computed_cpa == pytest.approx(red_cutoff)
-    assert computed_cpa >= i_cell.value * main_mod.RED_MULT - main_mod.CPA_TOL
+    assert computed_cpa >= i_cell.value * main_mod.YELLOW_MULT - main_mod.CPA_TOL
+    assert computed_cpa <= i_cell.value * main_mod.RED_MULT + main_mod.CPA_TOL
+
+    lower_cpa = 1.3 * ws[f"F{lower_row_excel}"].value / ws[f"E{lower_row_excel}"].value
+    assert lower_cpa == pytest.approx(target * main_mod.YELLOW_MULT)
 
     red_rule_formulae = []
     for rules in ws.conditional_formatting._cf_rules.values():
@@ -296,10 +319,14 @@ def test_classify_status_marks_red_only_above_cutoff_and_excel_rule_matches():
             if isinstance(formulas, str):
                 formulas = [formulas]
             for formula in formulas:
-                if "$H2>$I2" in formula:
+                if "$H2>$I2" in formula or "$H2>=$I2" in formula:
                     red_rule_formulae.append(formula)
 
-    assert any(f"$H2>$I2*{main_mod.RED_MULT:.2f}" in f for f in red_rule_formulae)
+    assert any(
+        (f"$H2>=$I2*{main_mod.YELLOW_MULT:.2f}" in f)
+        and (f"$H2<=$I2*{main_mod.RED_MULT:.2f}" in f)
+        for f in red_rule_formulae
+    )
 
 
 def test_allocation_explanation_reflects_custom_targets_in_status_counts():
@@ -327,8 +354,8 @@ def test_allocation_explanation_reflects_custom_targets_in_status_counts():
         alloc_is_delta=False,
     )
 
-    assert "Жовтих ДО/ПІСЛЯ: 0 → 0" in explanation
-    assert "Grey → Grey" in explanation
+    assert "Жовтих ДО/ПІСЛЯ: 1 → 0" in explanation
+    assert "Yellow → Red" in explanation
 
 
 def test_read_result_allocation_table_handles_formula_total_plus_percent(tmp_path):


### PR DESCRIPTION
## Summary
- update status classification logic and supporting thresholds to honour the new red CPA band
- adjust Excel conditional formatting and descriptive messaging to the revised thresholds
- refresh unit tests to reflect the deposit-driven yellow rules and the bounded red zone

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d9b59415648323aebbcf64b924fb51